### PR TITLE
move networkchainID state value from settings to wallet reducer

### DIFF
--- a/crosscash-extension/src/popup/pages/index.tsx
+++ b/crosscash-extension/src/popup/pages/index.tsx
@@ -26,7 +26,7 @@ export const Routes = () => {
         process.env.REACT_APP_ALCHEMY_API_KEY,
     );
 
-    const currentChainID = useAppSelector((state) => state.settings.currentNetworkChainId);
+    const currentChainID = useAppSelector((state) => state.wallet.currentNetworkChainId);
 
     const ethNetwork = getEthereumNetwork(currentChainID);
 

--- a/crosscash-extension/src/popup/pages/wallet/Wallet.tsx
+++ b/crosscash-extension/src/popup/pages/wallet/Wallet.tsx
@@ -10,7 +10,7 @@ import {
     Stack,
 } from '../../components';
 import { useAppSelector } from '../../store';
-import { changeNetwork } from '../../store/settings/actions';
+import { changeNetwork } from '../../store/wallet/actions';
 import ConnectWallet from '../connections/ConnectWallet';
 import WalletNavBar from './WalletNavBar';
 
@@ -31,7 +31,7 @@ const Wallet = (): React.ReactElement => {
     };
 
     const dispatch = useDispatch();
-    const currentNetworkChainId = useAppSelector((state) => state.settings.currentNetworkChainId);
+    const currentNetworkChainId = useAppSelector((state) => state.wallet.currentNetworkChainId);
 
     const networkList = evmNetworks.map((n) => (
         <option

--- a/crosscash-extension/src/popup/store/settings/actions.ts
+++ b/crosscash-extension/src/popup/store/settings/actions.ts
@@ -17,16 +17,4 @@ export const setDefaultGasSpeed = (g: GasSpeed): SettingsActionTypes => ({
     type: SET_DEFAULT_GAS_SPEED,
 });
 
-export const CHANGE_NETWORK = 'CHANGE_NETWORK';
-
-type NetworkActionType = {
-    payload: number;
-    type: typeof CHANGE_NETWORK;
-};
-
-export const changeNetwork = (chainId: number): SettingsActionTypes => ({
-    payload: chainId,
-    type: CHANGE_NETWORK,
-});
-
-export type SettingsActionTypes = GasActionType | NetworkActionType;
+export type SettingsActionTypes = GasActionType;

--- a/crosscash-extension/src/popup/store/settings/reducer.ts
+++ b/crosscash-extension/src/popup/store/settings/reducer.ts
@@ -1,10 +1,8 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 
-import { MAINNET } from '../../../lib/constants/networks';
 import {
     GasSpeed,
     SET_DEFAULT_GAS_SPEED,
-    CHANGE_NETWORK,
 } from './actions';
 
 const initialState: SettingsState = {
@@ -12,7 +10,6 @@ const initialState: SettingsState = {
         speed: 'fast',
         confidence: 99,
     },
-    currentNetworkChainId: MAINNET.chainID,
     loading: false,
     error: null,
 };
@@ -27,11 +24,6 @@ const settingsReducer = (
                 ...state,
                 defaultGasSpeed: action.payload,
             };
-        case CHANGE_NETWORK:
-            return {
-                ...state,
-                currentNetworkChainId: action.payload,
-            };
         default:
             return state;
     }
@@ -40,7 +32,6 @@ const settingsReducer = (
 export type SettingsState = {
     defaultGasSpeed: GasSpeed;
     loading: boolean;
-    currentNetworkChainId: number;
     error: Error | null;
 }
 

--- a/crosscash-extension/src/popup/store/wallet/actions.ts
+++ b/crosscash-extension/src/popup/store/wallet/actions.ts
@@ -1,3 +1,20 @@
 import { createRoutine } from 'redux-saga-routines';
 
+import { Network } from '../../../lib/networks';
+import { EthereumWallet } from '../../model/wallet';
+
+type NetworkActionType = {
+    payload: number;
+    type: typeof CHANGE_NETWORK;
+};
+
 export const createWallet = createRoutine('CREATE_WALLET');
+
+export const CHANGE_NETWORK = 'CHANGE_NETWORK';
+
+export const changeNetwork = (chainId: number): NetworkActionType => ({
+    payload: chainId,
+    type: CHANGE_NETWORK,
+});
+
+export type WalletPayloadAction = EthereumWallet & Network['chainID'] & Error;

--- a/crosscash-extension/src/popup/store/wallet/reducer.ts
+++ b/crosscash-extension/src/popup/store/wallet/reducer.ts
@@ -1,17 +1,23 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 
+import { MAINNET } from '../../../lib/constants/networks';
 import { EthereumWallet } from '../../model/wallet';
-import { createWallet } from './actions';
+import {
+    createWallet,
+    CHANGE_NETWORK,
+    WalletPayloadAction,
+} from './actions';
 
 const initialState: WalletState = {
     walletInstance: null,
+    currentNetworkChainId: MAINNET.chainID,
     loading: false,
     error: null,
 };
 
 export const walletReducer = (
     state = initialState,
-    action: PayloadAction<EthereumWallet & Error>,
+    action: PayloadAction<WalletPayloadAction>,
 ): WalletState => {
     switch (action.type) {
         case createWallet.TRIGGER:
@@ -31,6 +37,11 @@ export const walletReducer = (
                 ...state,
                 loading: false,
             };
+        case CHANGE_NETWORK:
+            return {
+                ...state,
+                currentNetworkChainId: action.payload,
+            };
         default:
             return state;
     }
@@ -38,6 +49,7 @@ export const walletReducer = (
 
 export interface WalletState {
     walletInstance: EthereumWallet | null;
+    currentNetworkChainId: number;
     loading: boolean;
     error: Error | null;
 }


### PR DESCRIPTION
Everything related to wallet (address, network, public keys, walletconnect) will live in the wallet reducer for easier access to the state