### PR TITLE
Improvement/receive incoming transactions

### DIFF
--- a/crosscash-extension/src/lib/walletconnect/types.ts
+++ b/crosscash-extension/src/lib/walletconnect/types.ts
@@ -13,4 +13,5 @@ export type {
     RequestSessionPayload,
     IConnector,
     IWalletConnectOptions,
+    IJsonRpcRequest,
 };

--- a/crosscash-extension/src/popup/store/wallet/actions.ts
+++ b/crosscash-extension/src/popup/store/wallet/actions.ts
@@ -3,7 +3,10 @@ import { createRoutine } from 'redux-saga-routines';
 
 import { HexString } from '../../../lib/accounts';
 import { Network } from '../../../lib/networks';
-import { RequestSessionPayload } from '../../../lib/walletconnect/types';
+import {
+    RequestSessionPayload,
+    IJsonRpcRequest,
+} from '../../../lib/walletconnect/types';
 import { EthereumWallet } from '../../model/wallet';
 
 type NetworkActionType = {
@@ -48,10 +51,13 @@ export const rejectRequestSession = createRoutine('REJECT_REQUEST_SESSION_WITH_D
 // disconnect from walletconnect
 export const disconnectSession = createRoutine('DISCONNECT_SESSION');
 
+export const callRequest = createRoutine('CALL_REQUEST');
+
 export type WalletPayloadAction = EthereumWallet
     & Network['chainID']
     & WalletConnect
     & RequestSessionPayload
     & RequestSessionWithDapp
+    & IJsonRpcRequest
     & Error;
 

--- a/crosscash-extension/src/popup/store/wallet/reducer.ts
+++ b/crosscash-extension/src/popup/store/wallet/reducer.ts
@@ -6,6 +6,7 @@ import { MAINNET } from '../../../lib/constants/networks';
 import {
     RequestSessionPayload,
     IConnector,
+    IJsonRpcRequest,
 } from '../../../lib/walletconnect/types';
 import { EthereumWallet } from '../../model/wallet';
 import {
@@ -17,6 +18,7 @@ import {
     confirmRequestSession,
     rejectRequestSession,
     disconnectSession,
+    callRequest,
 } from './actions';
 
 const initialState: WalletState = {
@@ -24,6 +26,7 @@ const initialState: WalletState = {
     pendingRequest: null,
     connector: null,
     currentSessionApproved: false,
+    callRequest: null,
     walletInstance: null,
     currentNetworkChainId: MAINNET.chainID,
     loading: false,
@@ -159,6 +162,26 @@ export const walletReducer = (
                 ...state,
                 loading: false,
             };
+        case callRequest.TRIGGER:
+            return {
+                ...state,
+                loading: true,
+            };
+        case callRequest.SUCCESS:
+            return {
+                ...state,
+                callRequest: action.payload,
+            };
+        case callRequest.FAILURE:
+            return {
+                ...state,
+                error: action.payload,
+            };
+        case callRequest.FULFILL:
+            return {
+                ...state,
+                loading: false,
+            };
         default:
             return state;
     }
@@ -173,6 +196,7 @@ export interface WalletState {
     pendingRequest: RequestSessionPayload | null;
     connector: WalletConnect | null;
     currentSessionApproved: boolean;
+    callRequest: IJsonRpcRequest | null;
     walletInstance: EthereumWallet | null;
     currentNetworkChainId: number;
     loading: boolean;


### PR DESCRIPTION
`callRequest` key have the value that gets updated in the store coming from wallet_connect `call_request`. Once we have that value, we can handle it accordingly to whatever method we get to `eth_sign`, `personal_sign`, `eth_sendTransaction`, `eth_signTransaction`. 

This channel is never closed for now so a user can call multiple transactions, once after the other.